### PR TITLE
Added jacoco report execution

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -106,6 +106,12 @@
               <goal>prepare-agent</goal>
             </goals>
           </execution>
+          <execution>
+            <id>report</id>
+            <goals>
+              <goal>report</goal>
+            </goals>
+          </execution>
         </executions>
       </plugin>
 


### PR DESCRIPTION
this is how the jacoco.exec will be populated.  without this
prepare-agent is not really useful to be on the builds.
