### PR TITLE
Fix/then and packed exception for #23

### DIFF
--- a/catch-exception/src/main/java/com/googlecode/catchexception/CatchException.java
+++ b/catch-exception/src/main/java/com/googlecode/catchexception/CatchException.java
@@ -235,7 +235,7 @@ public class CatchException {
      *         caught exception belongs to a class that is no longer
      *         {@link ClassLoader loaded}.
      */
-    public static Exception caughtException() {
+    public static <E extends Exception> E caughtException() {
         return ExceptionHolder.get();
     }
 

--- a/catch-exception/src/main/java/com/googlecode/catchexception/apis/BDDCatchException.java
+++ b/catch-exception/src/main/java/com/googlecode/catchexception/apis/BDDCatchException.java
@@ -15,6 +15,8 @@
  */
 package com.googlecode.catchexception.apis;
 
+import static com.googlecode.catchexception.CatchException.caughtException;
+
 import com.googlecode.catchexception.CatchException;
 import org.assertj.core.api.AbstractThrowableAssert;
 import org.assertj.core.api.CompatibilityAssertions;
@@ -119,6 +121,10 @@ thenThrown(IndexOutOfBoundsException.class);
     public static AbstractThrowableAssert<?, ? extends Throwable> then(Exception actualException) {
         // delegate to AssertJ assertions
         return CompatibilityAssertions.assertThat(actualException);
+    }
+
+    public static CatchExceptionAssert thenCaughtException() {
+        return new CatchExceptionAssert(caughtException());
     }
 
 }

--- a/catch-exception/src/main/java/com/googlecode/catchexception/apis/BDDCatchException.java
+++ b/catch-exception/src/main/java/com/googlecode/catchexception/apis/BDDCatchException.java
@@ -15,11 +15,11 @@
  */
 package com.googlecode.catchexception.apis;
 
-import static com.googlecode.catchexception.CatchException.caughtException;
-
-import com.googlecode.catchexception.CatchException;
 import org.assertj.core.api.AbstractThrowableAssert;
 import org.assertj.core.api.CompatibilityAssertions;
+
+import com.googlecode.catchexception.CatchException;
+import com.googlecode.catchexception.internal.ExceptionHolder;
 
 /**
  * Supports <a
@@ -29,21 +29,21 @@ import org.assertj.core.api.CompatibilityAssertions;
  * EXAMPLE:
  * <code><pre class="prettyprint lang-java">import static org.assertj.core.api.BDDAssertions.then;
 
-// given an empty list
-List myList = new ArrayList();
+ // given an empty list
+ List myList = new ArrayList();
 
-// when we try to get the first element of the list
-when(myList).get(1);
+ // when we try to get the first element of the list
+ when(myList).get(1);
 
-// then we expect an IndexOutOfBoundsException
-then(caughtException())
-        .isInstanceOf(IndexOutOfBoundsException.class)
-        .hasMessage("Index: 1, Size: 0")
-        .hasNoCause();
+ // then we expect an IndexOutOfBoundsException
+ then(caughtException())
+ .isInstanceOf(IndexOutOfBoundsException.class)
+ .hasMessage("Index: 1, Size: 0")
+ .hasNoCause();
 
-// then we expect an IndexOutOfBoundsException (alternatively)
-thenThrown(IndexOutOfBoundsException.class);
-</pre></code>
+ // then we expect an IndexOutOfBoundsException (alternatively)
+ thenThrown(IndexOutOfBoundsException.class);
+ </pre></code>
  *
  * @author rwoo
  * @author mariuszs
@@ -73,24 +73,24 @@ public class BDDCatchException {
      * <p>
      * EXAMPLE:
      * <code><pre class="prettyprint lang-java">// given a list with nine members
-List myList = Arrays.asList(1, 2, 3, 4, 5, 6, 7, 8, 9);
+     List myList = Arrays.asList(1, 2, 3, 4, 5, 6, 7, 8, 9);
 
-// when we try to get the 500th member of the fellowship
-when(myList).get(500);
+     // when we try to get the 500th member of the fellowship
+     when(myList).get(500);
 
-// then we expect an IndexOutOfBoundsException
-thenThrown(IndexOutOfBoundsException.class);
-</pre></code>
+     // then we expect an IndexOutOfBoundsException
+     thenThrown(IndexOutOfBoundsException.class);
+     </pre></code>
      *
      * @param actualExceptionClazz
      *            the expected type of the caught exception.
      */
     @SuppressWarnings("rawtypes")
     public static void thenThrown(Class actualExceptionClazz) {
-      CatchExceptionUtils.thenThrown(actualExceptionClazz);
+        CatchExceptionUtils.thenThrown(actualExceptionClazz);
     }
 
-  /**
+    /**
      * Enables <a
      * href="https://github.com/joel-costigliola/assertj-core">AssertJ</a>
      * assertions about the caught exception.
@@ -112,7 +112,7 @@ thenThrown(IndexOutOfBoundsException.class);
      .hasNoCause();
      </pre></code>
      *
-     * @deprecated Use BDDAssertions#then instead
+     * @deprecated Use #then(ExceptionBox ) instead
      * @param actualException
      *            the value to be the target of the assertions methods.
      * @return Returns the created assertion object.
@@ -123,8 +123,38 @@ thenThrown(IndexOutOfBoundsException.class);
         return CompatibilityAssertions.assertThat(actualException);
     }
 
-    public static CatchExceptionAssert thenCaughtException() {
-        return new CatchExceptionAssert(caughtException());
+    /**
+     * Enables <a
+     * href="https://github.com/joel-costigliola/assertj-core">AssertJ</a>
+     * assertions about the caught exception.
+     * <p>
+     * EXAMPLE:
+     * <code><pre class="prettyprint lang-java">// given an empty list
+     List myList = new ArrayList();
+
+     // when we try to get first element of the list
+     when(myList).get(1);
+
+     // then we expect an IndexOutOfBoundsException
+     then(caughtException())
+     .isInstanceOf(IndexOutOfBoundsException.class)
+     .hasMessage("Index: 1, Size: 0")
+     .hasMessageStartingWith("Index: 1")
+     .hasMessageEndingWith("Size: 0")
+     .hasMessageContaining("Size")
+     .hasNoCause();
+     </pre></code>
+     *
+     * @param actualException
+     *            the value to be the target of the assertions methods.
+     * @return Returns the created assertion object.
+     */
+    public static CatchExceptionAssert then(ExceptionBox actualException) {
+        return new CatchExceptionAssert(actualException.getException());
+    }
+
+    public static ExceptionBox caughtException() {
+        return new ExceptionBox(ExceptionHolder.get());
     }
 
 }

--- a/catch-exception/src/main/java/com/googlecode/catchexception/apis/CatchExceptionAssert.java
+++ b/catch-exception/src/main/java/com/googlecode/catchexception/apis/CatchExceptionAssert.java
@@ -1,0 +1,26 @@
+/**
+ * Copyright (C) 2011 rwoo@gmx.de
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.googlecode.catchexception.apis;
+
+import org.assertj.core.api.AbstractThrowableAssert;
+
+public class CatchExceptionAssert extends AbstractThrowableAssert<CatchExceptionAssert, Exception> {
+
+    protected CatchExceptionAssert(Exception actual) {
+        super(actual, CatchExceptionAssert.class);
+    }
+
+}

--- a/catch-exception/src/main/java/com/googlecode/catchexception/apis/ExceptionBox.java
+++ b/catch-exception/src/main/java/com/googlecode/catchexception/apis/ExceptionBox.java
@@ -1,0 +1,29 @@
+/**
+ * Copyright (C) 2011 rwoo@gmx.de
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.googlecode.catchexception.apis;
+
+public class ExceptionBox {
+
+    private final Exception exception;
+
+    public ExceptionBox(Exception exception) {
+        this.exception = exception;
+    }
+
+    public Exception getException() {
+        return exception;
+    }
+}

--- a/catch-exception/src/test/java/com/googlecode/catchexception/apis/BDDCatchExceptionTest.java
+++ b/catch-exception/src/test/java/com/googlecode/catchexception/apis/BDDCatchExceptionTest.java
@@ -15,18 +15,18 @@
  */
 package com.googlecode.catchexception.apis;
 
-import org.junit.Test;
+import static com.googlecode.catchexception.apis.BDDCatchException.caughtException;
+import static com.googlecode.catchexception.apis.BDDCatchException.then;
+import static com.googlecode.catchexception.apis.BDDCatchException.thenThrown;
+import static com.googlecode.catchexception.apis.BDDCatchException.when;
+import static org.junit.Assert.assertEquals;
 
+import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
-import static com.googlecode.catchexception.CatchException.caughtException;
-import static com.googlecode.catchexception.apis.BDDCatchException.thenCaughtException;
-import static com.googlecode.catchexception.apis.BDDCatchException.thenThrown;
-import static com.googlecode.catchexception.apis.BDDCatchException.when;
-import static com.googlecode.catchexception.apis.BDDCatchException.then;
-import static org.junit.Assert.assertEquals;
+import org.junit.Test;
 
 /**
  * Tests {@link com.googlecode.catchexception.apis.BDDCatchException}.
@@ -47,22 +47,6 @@ public class BDDCatchExceptionTest {
 
         // then we expect an IndexOutOfBoundsException
         then(caughtException()) //
-                .isInstanceOf(IndexOutOfBoundsException.class) //
-                .hasMessage("Index: 1, Size: 0") //
-                .hasNoCause();
-
-    }
-    @SuppressWarnings("rawtypes")
-    @Test
-    public void testThenCaughtException() {
-        // given an empty list
-        List myList = new ArrayList();
-
-        // when we try to get first element of the list
-        when(myList).get(1);
-
-        // then we expect an IndexOutOfBoundsException
-        thenCaughtException()
                 .isInstanceOf(IndexOutOfBoundsException.class) //
                 .hasMessage("Index: 1, Size: 0") //
                 .hasNoCause();

--- a/catch-exception/src/test/java/com/googlecode/catchexception/apis/BDDCatchExceptionTest.java
+++ b/catch-exception/src/test/java/com/googlecode/catchexception/apis/BDDCatchExceptionTest.java
@@ -22,6 +22,7 @@ import java.util.Arrays;
 import java.util.List;
 
 import static com.googlecode.catchexception.CatchException.caughtException;
+import static com.googlecode.catchexception.apis.BDDCatchException.thenCaughtException;
 import static com.googlecode.catchexception.apis.BDDCatchException.thenThrown;
 import static com.googlecode.catchexception.apis.BDDCatchException.when;
 import static com.googlecode.catchexception.apis.BDDCatchException.then;
@@ -37,7 +38,7 @@ public class BDDCatchExceptionTest {
 
     @SuppressWarnings("rawtypes")
     @Test
-    public void testAssertThat() {
+    public void testThen() {
         // given an empty list
         List myList = new ArrayList();
 
@@ -46,6 +47,22 @@ public class BDDCatchExceptionTest {
 
         // then we expect an IndexOutOfBoundsException
         then(caughtException()) //
+                .isInstanceOf(IndexOutOfBoundsException.class) //
+                .hasMessage("Index: 1, Size: 0") //
+                .hasNoCause();
+
+    }
+    @SuppressWarnings("rawtypes")
+    @Test
+    public void testThenCaughtException() {
+        // given an empty list
+        List myList = new ArrayList();
+
+        // when we try to get first element of the list
+        when(myList).get(1);
+
+        // then we expect an IndexOutOfBoundsException
+        thenCaughtException()
                 .isInstanceOf(IndexOutOfBoundsException.class) //
                 .hasMessage("Index: 1, Size: 0") //
                 .hasNoCause();

--- a/catch-throwable/src/main/java/com/googlecode/catchexception/throwable/CatchThrowable.java
+++ b/catch-throwable/src/main/java/com/googlecode/catchexception/throwable/CatchThrowable.java
@@ -42,7 +42,7 @@ public class CatchThrowable {
      *         not caught an throwable. Returns null if the caught throwable belongs to a class that is no longer
      *         {@link ClassLoader loaded}.
      */
-    public static Throwable caughtThrowable() {
+    public static <E extends Throwable> E  caughtThrowable() {
         return ThrowableHolder.get();
     }
 

--- a/catch-throwable/src/main/java/com/googlecode/catchexception/throwable/apis/BDDCatchThrowable.java
+++ b/catch-throwable/src/main/java/com/googlecode/catchexception/throwable/apis/BDDCatchThrowable.java
@@ -15,6 +15,8 @@
  */
 package com.googlecode.catchexception.throwable.apis;
 
+import static com.googlecode.catchexception.throwable.CatchThrowable.caughtThrowable;
+
 import com.googlecode.catchexception.throwable.CatchThrowable;
 import org.assertj.core.api.AbstractThrowableAssert;
 import org.assertj.core.api.CompatibilityAssertions;
@@ -113,5 +115,9 @@ thenThrown(IndexOutOfBoundsThrowable.class);
   public static AbstractThrowableAssert<?, ? extends Throwable> then(Throwable actualThrowable) {
     // delegate to AssertJ assertions
     return CompatibilityAssertions.assertThat(actualThrowable);
+  }
+
+  public static CatchThrowableAssert thenCaughtThrowable() {
+    return new CatchThrowableAssert(caughtThrowable());
   }
 }

--- a/catch-throwable/src/main/java/com/googlecode/catchexception/throwable/apis/BDDCatchThrowable.java
+++ b/catch-throwable/src/main/java/com/googlecode/catchexception/throwable/apis/BDDCatchThrowable.java
@@ -15,33 +15,34 @@
  */
 package com.googlecode.catchexception.throwable.apis;
 
-import static com.googlecode.catchexception.throwable.CatchThrowable.caughtThrowable;
-
-import com.googlecode.catchexception.throwable.CatchThrowable;
 import org.assertj.core.api.AbstractThrowableAssert;
 import org.assertj.core.api.CompatibilityAssertions;
+
+import com.googlecode.catchexception.throwable.CatchThrowable;
+import com.googlecode.catchexception.throwable.internal.ThrowableHolder;
 
 /**
  * Supports <a href="http://en.wikipedia.org/wiki/Behavior_Driven_Development">BDD</a>-like approach to catch and verify
  * throwables (<i>given/when/then</i>).
  * <p>
- * <code><pre class="prettyprint lang-java">import static com.googlecode.catchexception.throwable.apis.BDDCatchThrowable.*;
+ * <code><pre class="prettyprint lang-java">import static com.googlecode.catchexception.throwable.apis
+ * .BDDCatchThrowable.*;
 
  // given an empty list
-List myList = new ArrayList();
+ List myList = new ArrayList();
 
-// when we try to get the first element of the list
-when(myList).get(1);
+ // when we try to get the first element of the list
+ when(myList).get(1);
 
-// then we expect an IndexOutOfBoundsThrowable
-then(caughtThrowable())
-        .isInstanceOf(IndexOutOfBoundsThrowable.class)
-        .hasMessage("Index: 1, Size: 0")
-        .hasNoCause();
+ // then we expect an IndexOutOfBoundsThrowable
+ then(caughtThrowable())
+ .isInstanceOf(IndexOutOfBoundsThrowable.class)
+ .hasMessage("Index: 1, Size: 0")
+ .hasNoCause();
 
-// then we expect an IndexOutOfBoundsThrowable (alternatively)
-thenThrown(IndexOutOfBoundsThrowable.class);
-</pre></code>
+ // then we expect an IndexOutOfBoundsThrowable (alternatively)
+ thenThrown(IndexOutOfBoundsThrowable.class);
+ </pre></code>
  *
  * @author rwoo
  * @author mariuszs
@@ -62,7 +63,7 @@ public class BDDCatchThrowable {
      * @see com.googlecode.catchexception.throwable.CatchThrowable#catchThrowable(Object)
      */
     public static <T> T when(T obj) {
-      return CatchThrowable.catchThrowable(obj);
+        return CatchThrowable.catchThrowable(obj);
     }
 
     /**
@@ -70,54 +71,84 @@ public class BDDCatchThrowable {
      * <p>
      * EXAMPLE:
      * <code><pre class="prettyprint lang-java">// given a list with nine members
-List myList = Arrays.asList(1, 2, 3, 4, 5, 6, 7, 8, 9);
+     List myList = Arrays.asList(1, 2, 3, 4, 5, 6, 7, 8, 9);
 
-// when we try to get the 500th member of the fellowship
-when(myList).get(500);
+     // when we try to get the 500th member of the fellowship
+     when(myList).get(500);
 
-// then we expect an IndexOutOfBoundsThrowable
-thenThrown(IndexOutOfBoundsThrowable.class);
-</pre></code>
+     // then we expect an IndexOutOfBoundsThrowable
+     thenThrown(IndexOutOfBoundsThrowable.class);
+     </pre></code>
      *
      * @param actualThrowableClazz
      *            the expected type of the caught throwable.
      */
     @SuppressWarnings("rawtypes")
     public static void thenThrown(Class actualThrowableClazz) {
-      CatchThrowable.catchThrowable(actualThrowableClazz);    }
+        CatchThrowable.catchThrowable(actualThrowableClazz);
+    }
 
-  /**
-   * Enables <a href="https://github.com/joel-costigliola/assertj-core">AssertJ</a> assertions about the caught
-   * throwable.
-   * <p>
-   * EXAMPLE: <code><pre class="prettyprint lang-java">// given an empty list
-   List myList = new ArrayList();
+    /**
+     * Enables <a href="https://github.com/joel-costigliola/assertj-core">AssertJ</a> assertions about the caught
+     * throwable.
+     * <p>
+     * EXAMPLE: <code><pre class="prettyprint lang-java">// given an empty list
+     List myList = new ArrayList();
 
-   // when we try to get first element of the list
-   when(myList).get(1);
+     // when we try to get first element of the list
+     when(myList).get(1);
 
-   // then we expect an IndexOutOfBoundsThrowable
-   then(caughtThrowable())
-   .isInstanceOf(IndexOutOfBoundsThrowable.class)
-   .hasMessage("Index: 1, Size: 0")
-   .hasMessageStartingWith("Index: 1")
-   .hasMessageEndingWith("Size: 0")
-   .hasMessageContaining("Size")
-   .hasNoCause();
-   </pre></code>
-   *
-   * @deprecated Use BDDAssertions#then instead
-   * @param actualThrowable
-   *            the value to be the target of the assertions methods.
-   * @return Returns the created assertion object.
-   */
-  @Deprecated
-  public static AbstractThrowableAssert<?, ? extends Throwable> then(Throwable actualThrowable) {
-    // delegate to AssertJ assertions
-    return CompatibilityAssertions.assertThat(actualThrowable);
-  }
+     // then we expect an IndexOutOfBoundsThrowable
+     then(caughtThrowable())
+     .isInstanceOf(IndexOutOfBoundsThrowable.class)
+     .hasMessage("Index: 1, Size: 0")
+     .hasMessageStartingWith("Index: 1")
+     .hasMessageEndingWith("Size: 0")
+     .hasMessageContaining("Size")
+     .hasNoCause();
+     </pre></code>
+     *
+     * @deprecated Use #then(ThrowableBox) instead
+     * @param actualThrowable
+     *            the value to be the target of the assertions methods.
+     * @return Returns the created assertion object.
+     */
+    @Deprecated
+    public static AbstractThrowableAssert<?, ? extends Throwable> then(Throwable actualThrowable) {
+        // delegate to AssertJ assertions
+        return CompatibilityAssertions.assertThat(actualThrowable);
+    }
 
-  public static CatchThrowableAssert thenCaughtThrowable() {
-    return new CatchThrowableAssert(caughtThrowable());
-  }
+    /**
+     * Enables <a href="https://github.com/joel-costigliola/assertj-core">AssertJ</a> assertions about the caught
+     * throwable.
+     * <p>
+     * EXAMPLE: <code><pre class="prettyprint lang-java">// given an empty list
+     List myList = new ArrayList();
+
+     // when we try to get first element of the list
+     when(myList).get(1);
+
+     // then we expect an IndexOutOfBoundsThrowable
+     then(caughtThrowable())
+     .isInstanceOf(IndexOutOfBoundsThrowable.class)
+     .hasMessage("Index: 1, Size: 0")
+     .hasMessageStartingWith("Index: 1")
+     .hasMessageEndingWith("Size: 0")
+     .hasMessageContaining("Size")
+     .hasNoCause();
+     </pre></code>
+     *
+     * @param actualThrowable
+     *            the value to be the target of the assertions methods.
+     * @return Returns the created assertion object.
+     */
+    public static CatchThrowableAssert then(ThrowableBox actualThrowable) {
+        return new CatchThrowableAssert(actualThrowable.getThrowable());
+    }
+
+    public static ThrowableBox caughtThrowable() {
+        return new ThrowableBox(ThrowableHolder.get());
+    }
+
 }

--- a/catch-throwable/src/main/java/com/googlecode/catchexception/throwable/apis/CatchThrowableAssert.java
+++ b/catch-throwable/src/main/java/com/googlecode/catchexception/throwable/apis/CatchThrowableAssert.java
@@ -1,0 +1,26 @@
+/**
+ * Copyright (C) 2011 rwoo@gmx.de
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.googlecode.catchexception.throwable.apis;
+
+import org.assertj.core.api.AbstractThrowableAssert;
+
+public class CatchThrowableAssert extends AbstractThrowableAssert<CatchThrowableAssert, Throwable> {
+
+    protected CatchThrowableAssert(Throwable actual) {
+        super(actual, CatchThrowableAssert.class);
+    }
+
+}

--- a/catch-throwable/src/main/java/com/googlecode/catchexception/throwable/apis/ThrowableBox.java
+++ b/catch-throwable/src/main/java/com/googlecode/catchexception/throwable/apis/ThrowableBox.java
@@ -1,0 +1,29 @@
+/**
+ * Copyright (C) 2011 rwoo@gmx.de
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *         http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.googlecode.catchexception.throwable.apis;
+
+public class ThrowableBox {
+
+    private final Throwable throwable;
+
+    public ThrowableBox(Throwable throwable) {
+        this.throwable = throwable;
+    }
+
+    public Throwable getThrowable() {
+        return throwable;
+    }
+}

--- a/catch-throwable/src/test/java/com/googlecode/catchexception/throwable/apis/BDDCatchThrowableTest.java
+++ b/catch-throwable/src/test/java/com/googlecode/catchexception/throwable/apis/BDDCatchThrowableTest.java
@@ -22,6 +22,7 @@ import java.util.Arrays;
 import java.util.List;
 
 import static com.googlecode.catchexception.throwable.CatchThrowable.caughtThrowable;
+import static com.googlecode.catchexception.throwable.apis.BDDCatchThrowable.thenCaughtThrowable;
 import static com.googlecode.catchexception.throwable.apis.BDDCatchThrowable.thenThrown;
 import static com.googlecode.catchexception.throwable.apis.BDDCatchThrowable.when;
 import static com.googlecode.catchexception.throwable.apis.BDDCatchThrowable.then;
@@ -37,7 +38,7 @@ public class BDDCatchThrowableTest {
 
     @SuppressWarnings("rawtypes")
     @Test
-    public void testAssertThat() {
+    public void testThen() {
         // given an empty list
         List myList = new ArrayList();
 
@@ -45,7 +46,24 @@ public class BDDCatchThrowableTest {
         when(myList).get(1);
 
         // then we expect an IndexOutOfBoundsException
-        then(caughtThrowable()) //
+        then(caughtThrowable())
+            .isInstanceOf(IndexOutOfBoundsException.class) //
+            .hasMessage("Index: 1, Size: 0") //
+            .hasNoCause();
+
+    }
+
+    @SuppressWarnings("rawtypes")
+    @Test
+    public void testThenCaughtThrowable() {
+        // given an empty list
+        List myList = new ArrayList();
+
+        // when we try to get first element of the list
+        when(myList).get(1);
+
+        // then we expect an IndexOutOfBoundsException
+        thenCaughtThrowable()
             .isInstanceOf(IndexOutOfBoundsException.class) //
             .hasMessage("Index: 1, Size: 0") //
             .hasNoCause();

--- a/catch-throwable/src/test/java/com/googlecode/catchexception/throwable/apis/BDDCatchThrowableTest.java
+++ b/catch-throwable/src/test/java/com/googlecode/catchexception/throwable/apis/BDDCatchThrowableTest.java
@@ -15,18 +15,18 @@
  */
 package com.googlecode.catchexception.throwable.apis;
 
-import org.junit.Test;
+import static com.googlecode.catchexception.throwable.apis.BDDCatchThrowable.caughtThrowable;
+import static com.googlecode.catchexception.throwable.apis.BDDCatchThrowable.then;
+import static com.googlecode.catchexception.throwable.apis.BDDCatchThrowable.thenThrown;
+import static com.googlecode.catchexception.throwable.apis.BDDCatchThrowable.when;
+import static org.junit.Assert.assertEquals;
 
+import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
-import static com.googlecode.catchexception.throwable.CatchThrowable.caughtThrowable;
-import static com.googlecode.catchexception.throwable.apis.BDDCatchThrowable.thenCaughtThrowable;
-import static com.googlecode.catchexception.throwable.apis.BDDCatchThrowable.thenThrown;
-import static com.googlecode.catchexception.throwable.apis.BDDCatchThrowable.when;
-import static com.googlecode.catchexception.throwable.apis.BDDCatchThrowable.then;
-import static org.junit.Assert.assertEquals;
+import org.junit.Test;
 
 /**
  * Tests {@link com.googlecode.catchexception.throwable.apis.BDDCatchThrowable}.
@@ -47,9 +47,9 @@ public class BDDCatchThrowableTest {
 
         // then we expect an IndexOutOfBoundsException
         then(caughtThrowable())
-            .isInstanceOf(IndexOutOfBoundsException.class) //
-            .hasMessage("Index: 1, Size: 0") //
-            .hasNoCause();
+                .isInstanceOf(IndexOutOfBoundsException.class) //
+                .hasMessage("Index: 1, Size: 0") //
+                .hasNoCause();
 
     }
 
@@ -63,10 +63,10 @@ public class BDDCatchThrowableTest {
         when(myList).get(1);
 
         // then we expect an IndexOutOfBoundsException
-        thenCaughtThrowable()
-            .isInstanceOf(IndexOutOfBoundsException.class) //
-            .hasMessage("Index: 1, Size: 0") //
-            .hasNoCause();
+        then(caughtThrowable())
+                .isInstanceOf(IndexOutOfBoundsException.class) //
+                .hasMessage("Index: 1, Size: 0") //
+                .hasNoCause();
 
     }
 
@@ -101,7 +101,8 @@ public class BDDCatchThrowableTest {
         } catch (AssertionError e) {
             assertEquals("Throwable of type java.lang.IllegalArgumentException"
                             + " expected but was not thrown. Instead a throwable of"
-                            + " type class java.lang.ArrayIndexOutOfBoundsException" + " with message '500' was thrown.",
+                            + " type class java.lang.ArrayIndexOutOfBoundsException" + " with message '500' was " +
+                            "thrown.",
                     e.getMessage());
         }
 

--- a/catch-throwable/src/test/java/com/googlecode/catchexception/throwable/apis/CatchThrowableAssertJTest.java
+++ b/catch-throwable/src/test/java/com/googlecode/catchexception/throwable/apis/CatchThrowableAssertJTest.java
@@ -20,7 +20,7 @@ import org.junit.Test;
 import java.util.ArrayList;
 import java.util.List;
 
-import static com.googlecode.catchexception.throwable.CatchThrowable.caughtThrowable;
+import static com.googlecode.catchexception.throwable.apis.BDDCatchThrowable.caughtThrowable;
 import static com.googlecode.catchexception.throwable.apis.CatchThrowableAssertJ.when;
 import static com.googlecode.catchexception.throwable.apis.CatchThrowableAssertJ.then;
 import static org.junit.Assert.assertEquals;
@@ -51,19 +51,6 @@ public class CatchThrowableAssertJTest {
                 .hasMessageEndingWith("Size: 0") //
                 .hasMessageContaining("Size") //
                 .hasNoCause();
-
-        // test: caughtThrowable() == new RuntimeException()
-        try {
-            then(new RuntimeException()).isInstanceOf(IndexOutOfBoundsException.class);
-
-        } catch (AssertionError e) {
-            assertEquals("\nExpecting:" //
-                    + "\n <java.lang.RuntimeException>" //
-                    + "\nto be an instance of:" //
-                    + "\n <java.lang.IndexOutOfBoundsException>" //
-                    + "\nbut was instance of:" //
-                    + "\n <java.lang.RuntimeException>", e.getMessage());
-        }
 
         // test: caughtThrowable() has other unexpected message
         try {

--- a/functional-tests/catch-exception-assertj16/src/test/java/com/googlecode/catchexception/apis/BDDCatchExceptionAssertJ16Test.java
+++ b/functional-tests/catch-exception-assertj16/src/test/java/com/googlecode/catchexception/apis/BDDCatchExceptionAssertJ16Test.java
@@ -15,7 +15,7 @@
  */
 package com.googlecode.catchexception.apis;
 
-import static com.googlecode.catchexception.CatchException.caughtException;
+import static com.googlecode.catchexception.apis.CatchExceptionAssertJ.caughtException;
 import static com.googlecode.catchexception.apis.CatchExceptionAssertJ.then;
 import static com.googlecode.catchexception.apis.CatchExceptionAssertJ.when;
 import static org.junit.Assert.assertEquals;
@@ -91,7 +91,7 @@ public class BDDCatchExceptionAssertJ16Test extends BDDCatchExceptionTest {
         when(myList).get(1);
 
         // then we expect an IndexOutOfBoundsException
-        BDDCatchException.thenCaughtException() //
+        then(caughtException()) //
                 .isInstanceOf(IndexOutOfBoundsException.class) //
                 .hasMessage("Index: 1, Size: 0") //
                 .hasMessageStartingWith("Index: 1") //
@@ -115,7 +115,7 @@ public class BDDCatchExceptionAssertJ16Test extends BDDCatchExceptionTest {
 
         // test: caughtException() has other unexpected message
         try {
-            BDDCatchException.thenCaughtException() //
+            then(caughtException()) //
                     .isInstanceOf(IndexOutOfBoundsException.class) //
                     .hasMessage("Hi!");
 

--- a/functional-tests/catch-exception-assertj16/src/test/java/com/googlecode/catchexception/apis/BDDCatchExceptionAssertJ16Test.java
+++ b/functional-tests/catch-exception-assertj16/src/test/java/com/googlecode/catchexception/apis/BDDCatchExceptionAssertJ16Test.java
@@ -91,7 +91,7 @@ public class BDDCatchExceptionAssertJ16Test extends BDDCatchExceptionTest {
         when(myList).get(1);
 
         // then we expect an IndexOutOfBoundsException
-        BDDAssertions.then(caughtException()) //
+        BDDCatchException.thenCaughtException() //
                 .isInstanceOf(IndexOutOfBoundsException.class) //
                 .hasMessage("Index: 1, Size: 0") //
                 .hasMessageStartingWith("Index: 1") //
@@ -115,7 +115,7 @@ public class BDDCatchExceptionAssertJ16Test extends BDDCatchExceptionTest {
 
         // test: caughtException() has other unexpected message
         try {
-            BDDAssertions.then(caughtException()) //
+            BDDCatchException.thenCaughtException() //
                     .isInstanceOf(IndexOutOfBoundsException.class) //
                     .hasMessage("Hi!");
 

--- a/functional-tests/catch-exception-assertj17/src/test/java/com/googlecode/catchexception/apis/CatchExceptionAssertJ17Test.java
+++ b/functional-tests/catch-exception-assertj17/src/test/java/com/googlecode/catchexception/apis/CatchExceptionAssertJ17Test.java
@@ -89,7 +89,7 @@ public class CatchExceptionAssertJ17Test {
         when(myList).get(1);
 
         // then we expect an IndexOutOfBoundsException
-        BDDAssertions.then(caughtException()) //
+        BDDCatchException.thenCaughtException() //
                 .isInstanceOf(IndexOutOfBoundsException.class) //
                 .hasMessage("Index: 1, Size: 0") //
                 .hasMessageStartingWith("Index: 1") //
@@ -113,7 +113,7 @@ public class CatchExceptionAssertJ17Test {
 
         // test: caughtException() has other unexpected message
         try {
-            BDDAssertions.then(caughtException()) //
+            BDDCatchException.thenCaughtException() //
                     .isInstanceOf(IndexOutOfBoundsException.class) //
                     .hasMessage("Hi!");
 

--- a/functional-tests/catch-exception-assertj17/src/test/java/com/googlecode/catchexception/apis/CatchExceptionAssertJ17Test.java
+++ b/functional-tests/catch-exception-assertj17/src/test/java/com/googlecode/catchexception/apis/CatchExceptionAssertJ17Test.java
@@ -21,7 +21,7 @@ import org.junit.Test;
 import java.util.ArrayList;
 import java.util.List;
 
-import static com.googlecode.catchexception.CatchException.caughtException;
+import static com.googlecode.catchexception.apis.CatchExceptionAssertJ.caughtException;
 import static com.googlecode.catchexception.apis.CatchExceptionAssertJ.then;
 import static com.googlecode.catchexception.apis.CatchExceptionAssertJ.when;
 import static org.junit.Assert.assertEquals;
@@ -89,7 +89,7 @@ public class CatchExceptionAssertJ17Test {
         when(myList).get(1);
 
         // then we expect an IndexOutOfBoundsException
-        BDDCatchException.thenCaughtException() //
+        then(caughtException()) //
                 .isInstanceOf(IndexOutOfBoundsException.class) //
                 .hasMessage("Index: 1, Size: 0") //
                 .hasMessageStartingWith("Index: 1") //
@@ -113,7 +113,7 @@ public class CatchExceptionAssertJ17Test {
 
         // test: caughtException() has other unexpected message
         try {
-            BDDCatchException.thenCaughtException() //
+            then(caughtException()) //
                     .isInstanceOf(IndexOutOfBoundsException.class) //
                     .hasMessage("Hi!");
 

--- a/functional-tests/catch-throwable-assertj16/src/test/java/com/googlecode/catchexception/throwable/apis/BDDCatchThrowableAssertJ16Test.java
+++ b/functional-tests/catch-throwable-assertj16/src/test/java/com/googlecode/catchexception/throwable/apis/BDDCatchThrowableAssertJ16Test.java
@@ -20,9 +20,9 @@ import org.junit.Test;
 import java.util.ArrayList;
 import java.util.List;
 
-import static com.googlecode.catchexception.throwable.CatchThrowable.caughtThrowable;
-import static com.googlecode.catchexception.throwable.apis.BDDCatchThrowable.then;
-import static com.googlecode.catchexception.throwable.apis.BDDCatchThrowable.when;
+import static com.googlecode.catchexception.throwable.apis.CatchThrowableAssertJ.caughtThrowable;
+import static com.googlecode.catchexception.throwable.apis.CatchThrowableAssertJ.then;
+import static com.googlecode.catchexception.throwable.apis.CatchThrowableAssertJ.when;
 import static org.junit.Assert.assertEquals;
 
 /**

--- a/functional-tests/catch-throwable-assertj17/src/test/java/com/googlecode/catchexception/throwable/apis/CatchThrowableAssertJ17Test.java
+++ b/functional-tests/catch-throwable-assertj17/src/test/java/com/googlecode/catchexception/throwable/apis/CatchThrowableAssertJ17Test.java
@@ -20,7 +20,7 @@ import org.junit.Test;
 import java.util.ArrayList;
 import java.util.List;
 
-import static com.googlecode.catchexception.throwable.CatchThrowable.caughtThrowable;
+import static com.googlecode.catchexception.throwable.apis.CatchThrowableAssertJ.caughtThrowable;
 import static com.googlecode.catchexception.throwable.apis.CatchThrowableAssertJ.then;
 import static com.googlecode.catchexception.throwable.apis.CatchThrowableAssertJ.when;
 import static org.junit.Assert.assertEquals;
@@ -51,19 +51,6 @@ public class CatchThrowableAssertJ17Test {
                 .hasMessageEndingWith("Size: 0") //
                 .hasMessageContaining("Size") //
                 .hasNoCause();
-
-        // test: caughtThrowable() == new RuntimeException()
-        try {
-            then(new RuntimeException()).isInstanceOf(IndexOutOfBoundsException.class);
-
-        } catch (AssertionError e) {
-            assertEquals("\nExpecting:" //
-                    + "\n <java.lang.RuntimeException>" //
-                    + "\nto be an instance of:" //
-                    + "\n <java.lang.IndexOutOfBoundsException>" //
-                    + "\nbut was instance of:" //
-                    + "\n <java.lang.RuntimeException>", e.getMessage());
-        }
 
         // test: caughtThrowable() has other unexpected message
         try {


### PR DESCRIPTION
This allow proper #then again

```java
import static com.googlecode.catchexception.apis.BDDCatchException.*;

 List myList = new ArrayList();

        // when we try to get first element of the list
        when(myList).get(1);

        // then we expect an IndexOutOfBoundsException
        then(caughtException()) //
                .isInstanceOf(IndexOutOfBoundsException.class) //
                .hasMessage("Index: 1, Size: 0") //
                .hasNoCause();
```

