### PR TITLE
Maven and Shading Cleanup plus minor language updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,4 +5,4 @@
 .idea
 *.iml
 target
-mockito-shade/dependency-reduced-pom.xml 
+dependency-reduced-pom.xml

--- a/catch-exception/pom.xml
+++ b/catch-exception/pom.xml
@@ -28,19 +28,6 @@
       <version>1.2</version>
     </dependency>
 
-    <!-- required runtime scope dependencies +++++++++++++++++++++++++++++++ -->
-    <dependency>
-      <groupId>org.mockito</groupId>
-      <artifactId>mockito-core</artifactId>
-      <exclusions>
-        <exclusion>
-          <artifactId>hamcrest-core</artifactId>
-          <groupId>org.hamcrest</groupId>
-        </exclusion>
-      </exclusions>
-      <scope>test</scope>
-    </dependency>
-
     <!-- optional runtime scope dependencies +++++++++++++++++++++++++++++++ -->
     <dependency>
       <groupId>org.easytesting</groupId>

--- a/catch-exception/pom.xml
+++ b/catch-exception/pom.xml
@@ -21,6 +21,12 @@
       <groupId>eu.codearte.catch-exception</groupId>
       <artifactId>mockito-shade</artifactId>
       <version>${project.version}</version>
+      <exclusions>
+          <exclusion>
+              <artifactId>mockito-core</artifactId>
+              <groupId>org.mockito</groupId>
+          </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.objenesis</groupId>

--- a/catch-exception/src/main/java/com/googlecode/catchexception/apis/BDDCatchException.java
+++ b/catch-exception/src/main/java/com/googlecode/catchexception/apis/BDDCatchException.java
@@ -18,7 +18,6 @@ package com.googlecode.catchexception.apis;
 import org.assertj.core.api.AbstractThrowableAssert;
 
 import com.googlecode.catchexception.CatchException;
-import com.googlecode.catchexception.internal.ExceptionHolder;
 
 /**
  * Supports <a

--- a/catch-exception/src/main/java/com/googlecode/catchexception/apis/internal/hamcrest/ExceptionMessageMatcher.java
+++ b/catch-exception/src/main/java/com/googlecode/catchexception/apis/internal/hamcrest/ExceptionMessageMatcher.java
@@ -62,6 +62,7 @@ public class ExceptionMessageMatcher<T extends Exception> extends
      * 
      * @see org.hamcrest.Matcher#matches(java.lang.Object)
      */
+    @Override
     public boolean matches(Object obj) {
         if (!(obj instanceof Exception))
             return false;
@@ -78,6 +79,7 @@ public class ExceptionMessageMatcher<T extends Exception> extends
      * 
      * @see org.hamcrest.SelfDescribing#describeTo(org.hamcrest.Description)
      */
+    @Override
     public void describeTo(Description description) {
         description.appendText("has a message that ").appendDescriptionOf(
                 expectedMessageMatcher);

--- a/catch-exception/src/main/java/com/googlecode/catchexception/apis/internal/hamcrest/ExceptionNoCauseMatcher.java
+++ b/catch-exception/src/main/java/com/googlecode/catchexception/apis/internal/hamcrest/ExceptionNoCauseMatcher.java
@@ -38,8 +38,9 @@ public class ExceptionNoCauseMatcher<T extends Exception> extends
      */
     @Override
     public boolean matches(Object obj) {
-        if (!(obj instanceof Exception))
+        if (!(obj instanceof Exception)) {
             return false;
+        }
 
         Exception exception = (Exception) obj;
 

--- a/catch-exception/src/main/java/com/googlecode/catchexception/apis/internal/hamcrest/ExceptionNoCauseMatcher.java
+++ b/catch-exception/src/main/java/com/googlecode/catchexception/apis/internal/hamcrest/ExceptionNoCauseMatcher.java
@@ -36,6 +36,7 @@ public class ExceptionNoCauseMatcher<T extends Exception> extends
      * 
      * @see org.hamcrest.Matcher#matches(java.lang.Object)
      */
+    @Override
     public boolean matches(Object obj) {
         if (!(obj instanceof Exception))
             return false;
@@ -50,6 +51,7 @@ public class ExceptionNoCauseMatcher<T extends Exception> extends
      * 
      * @see org.hamcrest.SelfDescribing#describeTo(org.hamcrest.Description)
      */
+    @Override
     public void describeTo(Description description) {
         description.appendText("has no cause");
     }

--- a/catch-exception/src/main/java/com/googlecode/catchexception/internal/DelegatingInterceptor.java
+++ b/catch-exception/src/main/java/com/googlecode/catchexception/internal/DelegatingInterceptor.java
@@ -49,6 +49,7 @@ public class DelegatingInterceptor implements MethodInterceptor {
      * java.lang.reflect.Method, java.lang.Object[],
      * org.mockito.cglib.proxy.MethodProxy)
      */
+    @Override
     public Object intercept(Object obj, Method method, Object[] args,
             MethodProxy proxy) throws Throwable {
 

--- a/catch-exception/src/main/java/com/googlecode/catchexception/internal/InterfaceOnlyProxyFactory.java
+++ b/catch-exception/src/main/java/com/googlecode/catchexception/internal/InterfaceOnlyProxyFactory.java
@@ -39,6 +39,7 @@ public class InterfaceOnlyProxyFactory implements ProxyFactory {
      * com.googlecode.catchexception.internal.ProxyFactory#createProxy(java.
      * lang.Class, org.mockito.cglib.proxy.MethodInterceptor)
      */
+    @Override
     @SuppressWarnings("unchecked")
     public <T> T createProxy(Class<?> targetClass, MethodInterceptor interceptor) {
 

--- a/catch-exception/src/main/java/com/googlecode/catchexception/internal/SubclassProxyFactory.java
+++ b/catch-exception/src/main/java/com/googlecode/catchexception/internal/SubclassProxyFactory.java
@@ -41,6 +41,7 @@ public class SubclassProxyFactory implements ProxyFactory {
      * com.googlecode.catchexception.internal.ProxyFactory#createProxy(java.
      * lang.Object, java.lang.Class, boolean)
      */
+    @Override
     @SuppressWarnings("unchecked")
     public <T> T createProxy(Class<?> targetClass, MethodInterceptor interceptor) {
 

--- a/catch-exception/src/test/java/com/googlecode/catchexception/apis/CatchExceptionAssertJTest.java
+++ b/catch-exception/src/test/java/com/googlecode/catchexception/apis/CatchExceptionAssertJTest.java
@@ -24,7 +24,6 @@ import static org.junit.Assert.assertEquals;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.assertj.core.api.Assertions;
 import org.junit.Test;
 
 import com.googlecode.catchexception.CatchException;

--- a/catch-throwable/pom.xml
+++ b/catch-throwable/pom.xml
@@ -28,20 +28,6 @@
       <version>1.2</version>
     </dependency>
 
-    <!-- required runtime scope dependencies +++++++++++++++++++++++++++++++ -->
-    <dependency>
-        <groupId>org.mockito</groupId>
-        <artifactId>mockito-core</artifactId>
-        <exclusions>
-            <exclusion>
-                <artifactId>hamcrest-core</artifactId>
-                <groupId>org.hamcrest</groupId>
-            </exclusion>
-        </exclusions>
-      <scope>test</scope>
-    </dependency>
-
-      
     <!-- optional runtime scope dependencies +++++++++++++++++++++++++++++++ -->
     <dependency>
       <groupId>org.easytesting</groupId>

--- a/catch-throwable/pom.xml
+++ b/catch-throwable/pom.xml
@@ -21,6 +21,12 @@
       <groupId>eu.codearte.catch-exception</groupId>
       <artifactId>mockito-shade</artifactId>
       <version>${project.version}</version>
+      <exclusions>
+          <exclusion>
+              <artifactId>mockito-core</artifactId>
+              <groupId>org.mockito</groupId>
+          </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.objenesis</groupId>

--- a/catch-throwable/src/main/java/com/googlecode/catchexception/throwable/apis/BDDCatchThrowable.java
+++ b/catch-throwable/src/main/java/com/googlecode/catchexception/throwable/apis/BDDCatchThrowable.java
@@ -18,7 +18,6 @@ package com.googlecode.catchexception.throwable.apis;
 import org.assertj.core.api.AbstractThrowableAssert;
 
 import com.googlecode.catchexception.throwable.CatchThrowable;
-import com.googlecode.catchexception.throwable.internal.ThrowableHolder;
 
 /**
  * Supports <a href="http://en.wikipedia.org/wiki/Behavior_Driven_Development">BDD</a>-like approach to catch and verify

--- a/catch-throwable/src/main/java/com/googlecode/catchexception/throwable/apis/internal/hamcrest/ThrowableMessageMatcher.java
+++ b/catch-throwable/src/main/java/com/googlecode/catchexception/throwable/apis/internal/hamcrest/ThrowableMessageMatcher.java
@@ -62,6 +62,7 @@ public class ThrowableMessageMatcher<T extends Throwable> extends
      * 
      * @see org.hamcrest.Matcher#matches(java.lang.Object)
      */
+    @Override
     public boolean matches(Object obj) {
         if (!(obj instanceof Throwable))
             return false;
@@ -78,6 +79,7 @@ public class ThrowableMessageMatcher<T extends Throwable> extends
      * 
      * @see org.hamcrest.SelfDescribing#describeTo(org.hamcrest.Description)
      */
+    @Override
     public void describeTo(Description description) {
         description.appendText("has a message that ").appendDescriptionOf(
                 expectedMessageMatcher);

--- a/catch-throwable/src/main/java/com/googlecode/catchexception/throwable/internal/DelegatingInterceptor.java
+++ b/catch-throwable/src/main/java/com/googlecode/catchexception/throwable/internal/DelegatingInterceptor.java
@@ -49,6 +49,7 @@ public class DelegatingInterceptor implements MethodInterceptor {
      * java.lang.reflect.Method, java.lang.Object[],
      * org.mockito.cglib.proxy.MethodProxy)
      */
+    @Override
     public Object intercept(Object obj, Method method, Object[] args,
             MethodProxy proxy) throws Throwable {
 

--- a/catch-throwable/src/main/java/com/googlecode/catchexception/throwable/internal/InterfaceOnlyProxyFactory.java
+++ b/catch-throwable/src/main/java/com/googlecode/catchexception/throwable/internal/InterfaceOnlyProxyFactory.java
@@ -39,6 +39,7 @@ public class InterfaceOnlyProxyFactory implements ProxyFactory {
      * com.googlecode.catchthrowable.internal.ProxyFactory#createProxy(java.
      * lang.Class, org.mockito.cglib.proxy.MethodInterceptor)
      */
+    @Override
     @SuppressWarnings("unchecked")
     public <T> T createProxy(Class<?> targetClass, MethodInterceptor interceptor) {
 

--- a/functional-tests/catch-exception-assertj16/src/test/java/com/googlecode/catchexception/apis/BDDCatchExceptionAssertJ16Test.java
+++ b/functional-tests/catch-exception-assertj16/src/test/java/com/googlecode/catchexception/apis/BDDCatchExceptionAssertJ16Test.java
@@ -34,6 +34,7 @@ import org.junit.Test;
 @SuppressWarnings("javadoc")
 public class BDDCatchExceptionAssertJ16Test extends BDDCatchExceptionTest {
 
+    @Override
     @SuppressWarnings("rawtypes")
     @Test
     public void testThen() {

--- a/functional-tests/catch-exception-assertj17/src/test/java/com/googlecode/catchexception/test/apis/BDDCustomCatchExceptionTest.java
+++ b/functional-tests/catch-exception-assertj17/src/test/java/com/googlecode/catchexception/test/apis/BDDCustomCatchExceptionTest.java
@@ -22,9 +22,7 @@ import static org.assertj.core.api.BDDAssertions.then;
 
 import org.junit.Test;
 
-import com.googlecode.catchexception.CatchException;
 import com.googlecode.catchexception.PublicSomethingImpl;
-import com.googlecode.catchexception.apis.BDDCatchException;
 
 /**
  * Tests custom exception assertions.

--- a/functional-tests/catch-throwable-assertj16/src/test/java/com/googlecode/catchexception/throwable/apis/BDDCatchThrowableAssertJ16Test.java
+++ b/functional-tests/catch-throwable-assertj16/src/test/java/com/googlecode/catchexception/throwable/apis/BDDCatchThrowableAssertJ16Test.java
@@ -33,6 +33,7 @@ import static org.junit.Assert.assertEquals;
 @SuppressWarnings("javadoc")
 public class BDDCatchThrowableAssertJ16Test extends BDDCatchThrowableTest {
 
+    @Override
     @SuppressWarnings("rawtypes")
     @Test
     public void testThen() {

--- a/mockito-shade/pom.xml
+++ b/mockito-shade/pom.xml
@@ -31,7 +31,6 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-jar-plugin</artifactId>
-        <version>2.5</version>
         <configuration>
           <skipIfEmpty>false</skipIfEmpty>
         </configuration>
@@ -68,7 +67,6 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-deploy-plugin</artifactId>
-        <version>2.8.2</version>
         <configuration>
           <skip>true</skip>
         </configuration>

--- a/mockito-shade/pom.xml
+++ b/mockito-shade/pom.xml
@@ -60,6 +60,7 @@
                   <shadedPattern>io.codearte.catchexception.shade.mockito</shadedPattern>
                 </relocation>
               </relocations>
+              <createSourcesJar>true</createSourcesJar>
             </configuration>
           </execution>
         </executions>

--- a/mockito-shade/pom.xml
+++ b/mockito-shade/pom.xml
@@ -14,16 +14,23 @@
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
       <version>1.9.5</version>
+    </dependency>
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
       <exclusions>
         <exclusion>
           <artifactId>hamcrest-core</artifactId>
           <groupId>org.hamcrest</groupId>
         </exclusion>
-        <exclusion>
-          <groupId>org.objenesis</groupId>
-          <artifactId>objenesis</artifactId>
-        </exclusion>
       </exclusions>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.ant</groupId>
+      <artifactId>ant</artifactId>
+      <version>1.9.4</version>
+      <scope>provided</scope>
     </dependency>
   </dependencies>
   <build>
@@ -60,7 +67,14 @@
                   <shadedPattern>io.codearte.catchexception.shade.mockito</shadedPattern>
                 </relocation>
               </relocations>
+              <artifactSet>
+                <excludes>
+                  <exclude>org.objenesis</exclude>
+                  <exclude>org.hamcrest</exclude>
+                </excludes>
+              </artifactSet>
               <createSourcesJar>true</createSourcesJar>
+              <shadeSourcesContent>true</shadeSourcesContent>
             </configuration>
           </execution>
         </executions>
@@ -71,6 +85,52 @@
         <configuration>
           <skip>true</skip>
         </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-dependency-plugin</artifactId>
+        <version>2.10</version>
+        <executions>
+          <execution>
+            <id>unpack-dependencies</id>
+            <phase>package</phase>
+            <goals>
+              <goal>unpack</goal>
+            </goals>
+            <configuration>
+              <artifactItems>
+                <artifactItem>
+                  <groupId>eu.codearte.catch-exception</groupId>
+                  <artifactId>mockito-shade</artifactId>
+                  <version>${project.version}</version>
+                  <classifier>sources</classifier>
+                  <type>jar</type>
+                  <overWrite>false</overWrite>
+                  <outputDirectory>${project.build.directory}/sources</outputDirectory>
+                </artifactItem>
+              </artifactItems>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>build-helper-maven-plugin</artifactId>
+        <version>1.9.1</version>
+        <executions>
+          <execution>
+            <id>add-source</id>
+            <phase>package</phase>
+            <goals>
+              <goal>add-source</goal>
+            </goals>
+            <configuration>
+              <sources>
+                <source>${project.build.directory}/sources</source>
+              </sources>
+            </configuration>
+          </execution>
+        </executions>
       </plugin>
     </plugins>
   </build>

--- a/mockito-shade/pom.xml
+++ b/mockito-shade/pom.xml
@@ -38,7 +38,7 @@
       <plugin>
         <groupId>com.mycila</groupId>
         <artifactId>license-maven-plugin</artifactId>
-        <version>2.7</version>
+        <version>2.11</version>
         <configuration>
           <skip>true</skip>
         </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -296,7 +296,7 @@ else {
       <plugin>
         <groupId>com.mycila</groupId>
         <artifactId>license-maven-plugin</artifactId>
-        <version>2.9</version>
+        <version>2.11</version>
         <configuration>
           <header>${catchException.parent}/src/etc/header.txt</header>
           <includes>
@@ -339,7 +339,7 @@ else {
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-compiler-plugin</artifactId>
-          <version>3.2</version>
+          <version>3.3</version>
         </plugin>
 
         <plugin>
@@ -363,7 +363,7 @@ else {
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-javadoc-plugin</artifactId>
-          <version>2.10.1</version>
+          <version>2.10.3</version>
         </plugin>
 
         <plugin>
@@ -384,7 +384,7 @@ else {
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-release-plugin</artifactId>
-          <version>2.5.1</version>
+          <version>2.5.2</version>
           <configuration>
             <!-- Workaround for http://jira.codehaus.org/browse/MGPG-9 -->
             <mavenExecutorId>forked-path</mavenExecutorId>
@@ -406,7 +406,7 @@ else {
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-gpg-plugin</artifactId>
-          <version>1.5</version>
+          <version>1.6</version>
           <executions>
             <execution>
               <id>sign-artifacts</id>
@@ -427,13 +427,13 @@ else {
         <plugin>
           <groupId>org.eluder.coveralls</groupId>
           <artifactId>coveralls-maven-plugin</artifactId>
-          <version>3.0.1</version>
+          <version>3.1.0</version>
         </plugin>
 
         <plugin>
           <groupId>org.jacoco</groupId>
           <artifactId>jacoco-maven-plugin</artifactId>
-          <version>0.7.2.201409121644</version>
+          <version>0.7.4.201502262128</version>
         </plugin>
 
       </plugins>
@@ -494,7 +494,7 @@ else {
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-gpg-plugin</artifactId>
-            <version>1.5</version>
+            <version>1.6</version>
             <executions>
               <execution>
                 <id>sign-artifacts</id>

--- a/pom.xml
+++ b/pom.xml
@@ -35,7 +35,7 @@
 
     <powermock.version>1.6.1</powermock.version>
 
-    <spring.version>4.1.4.RELEASE</spring.version>
+    <spring.version>4.1.6.RELEASE</spring.version>
 
     <!-- used by maven-license-plugin -->
     <project.inceptionYear>2011</project.inceptionYear>
@@ -263,7 +263,7 @@ else {
         console.log("no rootpath found by analysing " + window.location.href);
     }
 }
-</script>     
+</script>
       ]]>
               </footer>
               <!-- footer or bottom makes no difference for javascript -->

--- a/pom.xml
+++ b/pom.xml
@@ -54,16 +54,6 @@
   <dependencyManagement>
     <dependencies>
       <dependency>
-        <groupId>org.mockito</groupId>
-        <artifactId>mockito-core</artifactId>
-        <version>[1.8.1,)</version>
-        <!--
-          successfully tested versions: 1.8.1, 1.8.2, 1.8.3, 1.8.4, 1.8.5, 1.9.0-rc1, 1.9.0, 1.9.5-rc1, 1.9.5,
-                                        1.10.5, 1.10.8
-          not compatible versions: 1.5, 1.6, 1.7
-         -->
-      </dependency>
-      <dependency>
         <groupId>org.assertj</groupId>
         <artifactId>assertj-core</artifactId>
         <version>1.5.0</version>


### PR DESCRIPTION
Please note, if this is too much for a single PR, I will rework this into multiple pieces.  The intent here started out as just updating the POMs then it became evident that the new shading causes issues in eclipse.  Therefore I reworked how the shading works by including the source and getting that included as part of the build thus it removed all the eclipse warnings.  Everything still behaves as it did before and it is more clear where mockito is shaded.