### PR TITLE
Update spring, ant, and enforcer plugin

### DIFF
--- a/mockito-shade/pom.xml
+++ b/mockito-shade/pom.xml
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
   <parent>
     <artifactId>catch-exception-parent</artifactId>
     <groupId>eu.codearte.catch-exception</groupId>
     <version>1.4.5-SNAPSHOT</version>
   </parent>
-  <modelVersion>4.0.0</modelVersion>
 
   <artifactId>mockito-shade</artifactId>
 
@@ -29,7 +29,7 @@
     <dependency>
       <groupId>org.apache.ant</groupId>
       <artifactId>ant</artifactId>
-      <version>1.9.4</version>
+      <version>1.9.6</version>
       <scope>provided</scope>
     </dependency>
   </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -342,7 +342,7 @@ else {
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-enforcer-plugin</artifactId>
-          <version>1.4</version>
+          <version>1.4.1</version>
         </plugin>
 
         <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
 
     <powermock.version>1.6.1</powermock.version>
 
-    <spring.version>4.1.6.RELEASE</spring.version>
+    <spring.version>4.2.1.RELEASE</spring.version>
 
     <!-- used by maven-license-plugin -->
     <project.inceptionYear>2011</project.inceptionYear>

--- a/pom.xml
+++ b/pom.xml
@@ -9,15 +9,6 @@
   <url>https://github.com/Codearte/catch-exception/</url>
   <name>catch-exception</name>
 
-  <!-- Disabled to workaround problem with old maven-gpg-plugin forced in release:prepare -->
-  <!--
-    <parent>
-      <groupId>org.sonatype.oss</groupId>
-      <artifactId>oss-parent</artifactId>
-      <version>9</version>
-    </parent>
-  -->
-
   <prerequisites>
     <maven>3.0.5</maven>
   </prerequisites>


### PR DESCRIPTION
Plus remove commented out sonatype as it is deprecated.