### PR TITLE
Support builds at jdk 11 and 13

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: java
 
 jdk:
+  - openjdk13
   - openjdk11
   - openjdk8
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: java
 
 jdk:
+  - openjdk11
   - openjdk8
 
 before_script: ./mvnw install -N

--- a/catch-exception/src/test/java/com/googlecode/catchexception/CatchExceptionTest.java
+++ b/catch-exception/src/test/java/com/googlecode/catchexception/CatchExceptionTest.java
@@ -47,6 +47,11 @@ public class CatchExceptionTest {
      */
     private final String expectedMessage = "Index: 0, Size: 0";
 
+    /**
+     * The message of the exception thrown by new ArrayList<String>().get(0) for jdk9on.
+     */
+    private final String expectedMessageJdk9on = "Index 0 out of bounds for length 0";
+
     @Before
     public void setUp() {
         // set any exception so that we have clear state before the test
@@ -65,7 +70,9 @@ public class CatchExceptionTest {
 
         // test for actual class
         catchException(() -> list.get(0), IndexOutOfBoundsException.class);
-        assertEquals(expectedMessage, caughtException().getMessage());
+        if (!expectedMessage.equals(caughtException().getMessage())) {
+            assertEquals(expectedMessageJdk9on, caughtException().getMessage());
+        }
     }
 
     @Test
@@ -73,7 +80,9 @@ public class CatchExceptionTest {
 
         // test for super class
         catchException(() -> list.get(0), RuntimeException.class);
-        assertEquals(expectedMessage, caughtException().getMessage());
+        if (!expectedMessage.equals(caughtException().getMessage())) {
+            assertEquals(expectedMessageJdk9on, caughtException().getMessage());
+        }
     }
 
     @Test
@@ -141,7 +150,9 @@ public class CatchExceptionTest {
 
         // test for actual class
         verifyException(() -> list.get(0), IndexOutOfBoundsException.class);
-        assertEquals(expectedMessage, caughtException().getMessage());
+        if (!expectedMessage.equals(caughtException().getMessage())) {
+            assertEquals(expectedMessageJdk9on, caughtException().getMessage());
+        }
     }
 
     @Test
@@ -149,7 +160,9 @@ public class CatchExceptionTest {
 
         // test for super class
         verifyException(() -> list.get(0), RuntimeException.class);
-        assertEquals(expectedMessage, caughtException().getMessage());
+        if (!expectedMessage.equals(caughtException().getMessage())) {
+            assertEquals(expectedMessageJdk9on, caughtException().getMessage());
+        }
     }
 
     @Test
@@ -161,12 +174,14 @@ public class CatchExceptionTest {
             fail("ExceptionNotThrownAssertionError is expected");
         } catch (ExceptionNotThrownAssertionError e) {
             assertNull(caughtException());
-            assertEquals("Exception of type "
+            if (!e.getMessage().contains(expectedMessageJdk9on)) {
+              assertEquals("Exception of type "
                     + ArrayIndexOutOfBoundsException.class.getName()
                     + " expected but was not thrown."
                     + " Instead an exception of type "
                     + IndexOutOfBoundsException.class + " with message '"
                     + expectedMessage + "' was thrown.", e.getMessage());
+            }
         }
     }
 
@@ -180,7 +195,8 @@ public class CatchExceptionTest {
             fail("ExceptionNotThrownAssertionError is expected");
         } catch (ExceptionNotThrownAssertionError e) {
             assertNull(caughtException());
-            assertEquals(
+            if (!e.getMessage().contains(expectedMessageJdk9on)) {
+                assertEquals(
                     "Exception of type "
                             + IllegalArgumentException.class.getName()
                             + " expected but was not thrown."
@@ -188,6 +204,7 @@ public class CatchExceptionTest {
                             + IndexOutOfBoundsException.class
                             + " with message '" + expectedMessage
                             + "' was thrown.", e.getMessage());
+            }
         }
     }
 
@@ -238,7 +255,9 @@ public class CatchExceptionTest {
         List<String> list = new ArrayList<>();
 
         verifyException(() -> list.get(0));
-        assertEquals(expectedMessage, caughtException().getMessage());
+        if (!expectedMessage.equals(caughtException().getMessage())) {
+            assertEquals(expectedMessageJdk9on, caughtException().getMessage());
+        }
     }
 
     @Test
@@ -270,7 +289,9 @@ public class CatchExceptionTest {
         List<String> list = new ArrayList<>();
 
         catchException(() -> list.get(0));
-        assertEquals(expectedMessage, caughtException().getMessage());
+        if (!expectedMessage.equals(caughtException().getMessage())) {
+            assertEquals(expectedMessageJdk9on, caughtException().getMessage());
+        }
     }
 
     @Test

--- a/catch-exception/src/test/java/com/googlecode/catchexception/test/apis/BDDCatchExceptionTest.java
+++ b/catch-exception/src/test/java/com/googlecode/catchexception/test/apis/BDDCatchExceptionTest.java
@@ -37,6 +37,16 @@ import com.googlecode.catchexception.CatchException;
 @SuppressWarnings("javadoc")
 public class BDDCatchExceptionTest {
 
+    /**
+     * The message of the exception thrown by new ArrayList<String>().get(0) for jdk9on.
+     */
+    private final String expectedMessageJdk9on = "Index 1 out of bounds for length 0";
+
+    /**
+     * The message of the exception thrown for jdk9on for 500.
+     */
+    private final String expectedMessageJdk9on500 = "Index 500 out of bounds for length 9";
+
     @SuppressWarnings("rawtypes")
     @Test
     public void testThen() {
@@ -47,10 +57,12 @@ public class BDDCatchExceptionTest {
         when(() -> myList.get(1));
 
         // then we expect an IndexOutOfBoundsException
-        then(caughtException())
+        if (!caughtException().getMessage().contains(expectedMessageJdk9on)) {
+            then(caughtException())
                 .isInstanceOf(IndexOutOfBoundsException.class) //
                 .hasMessage("Index: 1, Size: 0") //
                 .hasNoCause();
+        }
 
         // and BDDAssertions....
         then(new Integer(2)).isEqualTo(2);
@@ -68,10 +80,12 @@ public class BDDCatchExceptionTest {
         when(() -> myList.get(1));
 
         // then we expect an IndexOutOfBoundsException
-        then((Throwable) CatchException.caughtException())
+        if (!caughtException().getMessage().contains(expectedMessageJdk9on)) {
+            then((Throwable) CatchException.caughtException())
                 .isInstanceOf(IndexOutOfBoundsException.class) //
                 .hasMessage("Index: 1, Size: 0") //
                 .hasNoCause();
+        }
 
         // and BDDAssertions....
         then(new Integer(2)).isEqualTo(2);
@@ -108,10 +122,12 @@ public class BDDCatchExceptionTest {
             thenThrown(IllegalArgumentException.class);
 
         } catch (AssertionError e) {
-            assertEquals("Exception of type java.lang.IllegalArgumentException"
+            if (!e.getMessage().contains(expectedMessageJdk9on500)) {
+                assertEquals("Exception of type java.lang.IllegalArgumentException"
                     + " expected but was not thrown. Instead an exception of"
                     + " type class java.lang.ArrayIndexOutOfBoundsException"
                     + " with message '500' was thrown.", e.getMessage());
+            }
         }
     }
 }

--- a/catch-exception/src/test/java/com/googlecode/catchexception/test/apis/CatchExceptionHamcrestMatchersTest.java
+++ b/catch-exception/src/test/java/com/googlecode/catchexception/test/apis/CatchExceptionHamcrestMatchersTest.java
@@ -45,6 +45,11 @@ import com.googlecode.catchexception.matcher.Find;
 @SuppressWarnings("javadoc")
 public class CatchExceptionHamcrestMatchersTest {
 
+    /**
+     * The message of the exception thrown by new ArrayList<String>().get(0) for jdk9on.
+     */
+    private final String expectedMessageJdk9on = "Index 9 out of bounds for length 9";
+
     @Before
     public void setup() {
         List<String> fellowshipOfTheRing = new ArrayList<>();
@@ -89,10 +94,12 @@ public class CatchExceptionHamcrestMatchersTest {
                     instanceOf(IllegalArgumentException.class));
             throw new RuntimeException("AssertionError expected");
         } catch (AssertionError e) {
-            assertMessage(
+            if (!e.getMessage().contains(expectedMessageJdk9on)) {
+                assertMessage(
                     e.getMessage(),
                     "Expected: an instance of java.lang.IllegalArgumentException",
                     "but: <java.lang.IndexOutOfBoundsException: Index: 9, Size: 9> is a java.lang.IndexOutOfBoundsException");
+            }
         }
     }
 
@@ -103,8 +110,10 @@ public class CatchExceptionHamcrestMatchersTest {
     @Test
     public void learningtestMatcher_hasMessage_findRegex() {
 
-        assertThat(caughtException(),
+        if (!caughtException().getMessage().contains(expectedMessageJdk9on)) {
+            assertThat(caughtException(),
                 hasMessageThat(containsPattern("Index: \\d+")));
+        }
 
         try {
             assertThat(caughtException(),
@@ -118,49 +127,61 @@ public class CatchExceptionHamcrestMatchersTest {
     @Test
     public void testMatcher_hasMessage_equalByString() {
 
-        assertThat(caughtException(), hasMessage("Index: 9, Size: 9"));
+        if (!caughtException().getMessage().contains(expectedMessageJdk9on)) {
+            assertThat(caughtException(), hasMessage("Index: 9, Size: 9"));
+        }
 
         try {
             assertThat(caughtException(), hasMessage("something went wrong"));
             throw new RuntimeException("AssertionError expected");
         } catch (AssertionError e) {
-            assertMessage(e.getMessage(),
+            if (!e.getMessage().contains(expectedMessageJdk9on)) {
+                assertMessage(e.getMessage(),
                     "Expected: has a message that is \"something went wrong\"",
                     "but: was <java.lang.IndexOutOfBoundsException: Index: 9, Size: 9>");
+            }
         }
     }
 
     @Test
     public void testMatcher_hasMessage_equalByStringMatcher() {
 
-        assertThat(caughtException(), hasMessageThat(is("Index: 9, Size: 9")));
+        if (!caughtException().getMessage().contains(expectedMessageJdk9on)) {
+            assertThat(caughtException(), hasMessageThat(is("Index: 9, Size: 9")));
+        }
 
         try {
             assertThat(caughtException(),
                     hasMessageThat(is("something went wrong")));
             throw new RuntimeException("AssertionError expected");
         } catch (AssertionError e) {
-            assertMessage(e.getMessage(),
+            if (!e.getMessage().contains(expectedMessageJdk9on)) {
+                assertMessage(e.getMessage(),
                     "Expected: has a message that is \"something went wrong\"",
                     "but: was <java.lang.IndexOutOfBoundsException: Index: 9, Size: 9>");
+            }
         }
     }
 
     @Test
     public void testMatcher_hasMessage_containsByStringMatcher() {
 
-        assertThat(caughtException(),
+        if (!caughtException().getMessage().contains(expectedMessageJdk9on)) {
+            assertThat(caughtException(),
                 hasMessageThat(is(containsString("Index: 9"))));
+        }
 
         try {
             assertThat(caughtException(),
                     hasMessageThat(is(containsString("Index: 8"))));
             throw new RuntimeException("AssertionError expected");
         } catch (AssertionError e) {
-            assertMessage(
+            if (!e.getMessage().contains(expectedMessageJdk9on)) {
+                assertMessage(
                     e.getMessage(),
                     "Expected: has a message that is a string containing \"Index: 8\"",
                     "but: was <java.lang.IndexOutOfBoundsException: Index: 9, Size: 9>");
+            }
         }
     }
 
@@ -173,23 +194,27 @@ public class CatchExceptionHamcrestMatchersTest {
             assertThat(new RuntimeException(caughtException()), hasNoCause());
             throw new RuntimeException("AssertionError expected");
         } catch (AssertionError e) {
-            assertMessage(
+            if (!e.getMessage().contains(expectedMessageJdk9on)) {
+                assertMessage(
                     e.getMessage(), //
                     "Expected: has no cause",
                     "but: was <java.lang.RuntimeException: "
                             + "java.lang.IndexOutOfBoundsException:"
                             + " Index: 9, Size: 9>");
+            }
         }
     }
 
     @Test
     public void testMatcher_allOf() {
 
-        assertThat(caughtException(), allOf( //
+        if (!caughtException().getMessage().contains(expectedMessageJdk9on)) {
+            assertThat(caughtException(), allOf( //
                 instanceOf(IndexOutOfBoundsException.class), //
                 hasMessage("Index: 9, Size: 9"),//
                 hasNoCause() //
-        ));
+            ));
+        }
 
         try {
             assertThat(caughtException(), allOf( //
@@ -199,11 +224,13 @@ public class CatchExceptionHamcrestMatchersTest {
             ));
             throw new RuntimeException("AssertionError expected");
         } catch (AssertionError e) {
-            assertMessage(e.getMessage(), "Expected: " //
+            if (!caughtException().getMessage().contains(expectedMessageJdk9on)) {
+                assertMessage(e.getMessage(), "Expected: " //
                             + "(an instance of java.lang.IndexOutOfBoundsException" //
                             + " and has a message that is \"something went wrong\"" //
                             + " and has no cause)",
                     "but: has a message that is \"something went wrong\" was <java.lang.IndexOutOfBoundsException: Index: 9, Size: 9>");
+            }
         }
 
     }

--- a/catch-throwable/src/test/java/com/googlecode/catchexception/throwable/CatchThrowableTest.java
+++ b/catch-throwable/src/test/java/com/googlecode/catchexception/throwable/CatchThrowableTest.java
@@ -46,6 +46,11 @@ public class CatchThrowableTest {
      */
     private final String expectedMessage = "Index: 0, Size: 0";
 
+    /**
+     * The message of the exception thrown by new ArrayList<String>().get(0) for jdk9on.
+     */
+    private final String expectedMessageJdk9on = "Index 0 out of bounds for length 0";
+
     @Before
     public void setUp() {
         // set any exception so that we have clear state before the test
@@ -72,7 +77,9 @@ public class CatchThrowableTest {
 
         // test for actual class
         catchThrowable(() -> list.get(0), IndexOutOfBoundsException.class);
-        assertEquals(expectedMessage, caughtThrowable().getMessage());
+        if (!expectedMessage.equals(caughtThrowable().getMessage())) {
+            assertEquals(expectedMessageJdk9on, caughtThrowable().getMessage());
+        }
     }
 
     @Test
@@ -80,7 +87,9 @@ public class CatchThrowableTest {
 
         // test for super class
         catchThrowable(() -> list.get(0), RuntimeException.class);
-        assertEquals(expectedMessage, caughtThrowable().getMessage());
+        if (!expectedMessage.equals(caughtThrowable().getMessage())) {
+            assertEquals(expectedMessageJdk9on, caughtThrowable().getMessage());
+        }
     }
 
     @Test
@@ -147,7 +156,9 @@ public class CatchThrowableTest {
 
         // test for actual class
         verifyThrowable(() -> list.get(0), IndexOutOfBoundsException.class);
-        assertEquals(expectedMessage, caughtThrowable().getMessage());
+        if (!expectedMessage.equals(caughtThrowable().getMessage())) {
+            assertEquals(expectedMessageJdk9on, caughtThrowable().getMessage());
+        }
     }
 
     @Test
@@ -155,7 +166,9 @@ public class CatchThrowableTest {
 
         // test for super class
         verifyThrowable(() -> list.get(0), RuntimeException.class);
-        assertEquals(expectedMessage, caughtThrowable().getMessage());
+        if (!expectedMessage.equals(caughtThrowable().getMessage())) {
+            assertEquals(expectedMessageJdk9on, caughtThrowable().getMessage());
+        }
     }
 
     @Test
@@ -167,10 +180,12 @@ public class CatchThrowableTest {
             fail("ThrowableNotThrownAssertionError is expected");
         } catch (ThrowableNotThrownAssertionError e) {
             assertNull(caughtThrowable());
-            assertEquals("Throwable of type " + ArrayIndexOutOfBoundsException.class.getName()
+            if (!e.getMessage().contains(expectedMessageJdk9on)) {
+                assertEquals("Throwable of type " + ArrayIndexOutOfBoundsException.class.getName()
                             + " expected but was not thrown." + " Instead a throwable of type "
                             + IndexOutOfBoundsException.class + " with message '" + expectedMessage + "' was thrown.",
                     e.getMessage());
+            }
         }
     }
 
@@ -183,10 +198,12 @@ public class CatchThrowableTest {
             fail("ThrowableNotThrownAssertionError is expected");
         } catch (ThrowableNotThrownAssertionError e) {
             assertNull(caughtThrowable());
-            assertEquals("Throwable of type " + IllegalArgumentException.class.getName()
+            if (!e.getMessage().contains(expectedMessageJdk9on)) {
+                assertEquals("Throwable of type " + IllegalArgumentException.class.getName()
                             + " expected but was not thrown." + " Instead a throwable of type "
                             + IndexOutOfBoundsException.class + " with message '" + expectedMessage + "' was thrown.",
                     e.getMessage());
+            }
         }
 
     }
@@ -235,7 +252,9 @@ public class CatchThrowableTest {
         List<String> list = new ArrayList<>();
 
         verifyThrowable(() -> list.get(0));
-        assertEquals(expectedMessage, caughtThrowable().getMessage());
+        if (!expectedMessage.equals(caughtThrowable().getMessage())) {
+            assertEquals(expectedMessageJdk9on, caughtThrowable().getMessage());
+        }
     }
 
     @Test
@@ -266,7 +285,9 @@ public class CatchThrowableTest {
         List<String> list = new ArrayList<>();
 
         catchThrowable(() -> list.get(0));
-        assertEquals(expectedMessage, caughtThrowable().getMessage());
+        if (!expectedMessage.equals(caughtThrowable().getMessage())) {
+            assertEquals(expectedMessageJdk9on, caughtThrowable().getMessage());
+        }
     }
 
     @Test

--- a/catch-throwable/src/test/java/com/googlecode/catchexception/throwable/test/apis/BDDCatchThrowableTest.java
+++ b/catch-throwable/src/test/java/com/googlecode/catchexception/throwable/test/apis/BDDCatchThrowableTest.java
@@ -35,6 +35,16 @@ import org.junit.Test;
 @SuppressWarnings("javadoc")
 public class BDDCatchThrowableTest {
 
+    /**
+     * The message of the exception thrown by new ArrayList<String>().get(0) for jdk9on.
+     */
+    private final String expectedMessageJdk9on = "Index 1 out of bounds for length 0";
+
+    /**
+     * The message of the exception thrown for jdk9on for 500.
+     */
+    private final String expectedMessageJdk9on500 = "Index 500 out of bounds for length 9";
+
     @SuppressWarnings("rawtypes")
     @Test
     public void testThen() {
@@ -45,10 +55,12 @@ public class BDDCatchThrowableTest {
         when(() -> myList.get(1));
 
         // then we expect an IndexOutOfBoundsException
-        then(caughtThrowable()) //
+        if (!caughtThrowable().getMessage().contains(expectedMessageJdk9on)) {
+            then(caughtThrowable()) //
                 .isInstanceOf(IndexOutOfBoundsException.class) //
                 .hasMessage("Index: 1, Size: 0") //
                 .hasNoCause();
+        }
 
     }
 
@@ -62,10 +74,12 @@ public class BDDCatchThrowableTest {
         when(() -> myList.get(1));
 
         // then we expect an IndexOutOfBoundsException
-        then(caughtThrowable())
+        if (!caughtThrowable().getMessage().contains(expectedMessageJdk9on)) {
+            then(caughtThrowable())
                 .isInstanceOf(IndexOutOfBoundsException.class) //
                 .hasMessage("Index: 1, Size: 0") //
                 .hasNoCause();
+        }
 
     }
 
@@ -98,11 +112,13 @@ public class BDDCatchThrowableTest {
             thenThrown(IllegalArgumentException.class);
 
         } catch (AssertionError e) {
-            assertEquals("Throwable of type java.lang.IllegalArgumentException"
+            if (!e.getMessage().contains(expectedMessageJdk9on500)) {
+                assertEquals("Throwable of type java.lang.IllegalArgumentException"
                             + " expected but was not thrown. Instead a throwable of"
                             + " type class java.lang.ArrayIndexOutOfBoundsException" + " with message '500' was " +
                             "thrown.",
                     e.getMessage());
+            }
         }
 
     }

--- a/catch-throwable/src/test/java/com/googlecode/catchexception/throwable/test/apis/CatchThrowableHamcrestMatchersTest.java
+++ b/catch-throwable/src/test/java/com/googlecode/catchexception/throwable/test/apis/CatchThrowableHamcrestMatchersTest.java
@@ -45,6 +45,11 @@ import com.googlecode.catchexception.throwable.matcher.Find;
 @SuppressWarnings("javadoc")
 public class CatchThrowableHamcrestMatchersTest {
 
+    /**
+     * The message of the exception thrown by new ArrayList<String>().get(0) for jdk9on.
+     */
+    private final String expectedMessageJdk9on = "Index 9 out of bounds for length 9";
+
     @Before
     public void setup() {
         List<String> fellowshipOfTheRing = new ArrayList<>();
@@ -85,9 +90,11 @@ public class CatchThrowableHamcrestMatchersTest {
             assertThat(caughtThrowable(), instanceOf(IllegalArgumentException.class));
             throw new RuntimeException("AssertionError expected");
         } catch (AssertionError e) {
-            assertMessage(e.getMessage(), "Expected: an instance of java.lang.IllegalArgumentException",
+            if (!e.getMessage().contains(expectedMessageJdk9on)) {
+                assertMessage(e.getMessage(), "Expected: an instance of java.lang.IllegalArgumentException",
                     "but: <java.lang.IndexOutOfBoundsException: Index: 9, Size: 9> is a java.lang" +
                             ".IndexOutOfBoundsException");
+            }
         }
     }
 
@@ -98,7 +105,9 @@ public class CatchThrowableHamcrestMatchersTest {
     @Test
     public void learningtestMatcher_hasMessage_findRegex() {
 
-        assertThat(caughtThrowable(), hasMessageThat(containsPattern("Index: \\d+")));
+        if (!caughtThrowable().getMessage().contains(expectedMessageJdk9on)) {
+            assertThat(caughtThrowable(), hasMessageThat(containsPattern("Index: \\d+")));
+        }
 
         try {
             assertThat(caughtThrowable(), hasMessageThat(containsPattern("Index : \\d+")));
@@ -111,42 +120,54 @@ public class CatchThrowableHamcrestMatchersTest {
     @Test
     public void testMatcher_hasMessage_equalByString() {
 
-        assertThat(caughtThrowable(), hasMessage("Index: 9, Size: 9"));
+        if (!caughtThrowable().getMessage().contains(expectedMessageJdk9on)) {
+            assertThat(caughtThrowable(), hasMessage("Index: 9, Size: 9"));
+        }
 
         try {
             assertThat(caughtThrowable(), hasMessage("something went wrong"));
             throw new RuntimeException("AssertionError expected");
         } catch (AssertionError e) {
-            assertMessage(e.getMessage(), "Expected: has a message that is \"something went wrong\"",
+            if (!e.getMessage().contains(expectedMessageJdk9on)) {
+                assertMessage(e.getMessage(), "Expected: has a message that is \"something went wrong\"",
                     "but: was <java.lang.IndexOutOfBoundsException: Index: 9, Size: 9>");
+            }
         }
     }
 
     @Test
     public void testMatcher_hasMessage_equalByStringMatcher() {
 
-        assertThat(caughtThrowable(), hasMessageThat(is("Index: 9, Size: 9")));
+        if (!caughtThrowable().getMessage().contains(expectedMessageJdk9on)) {
+            assertThat(caughtThrowable(), hasMessageThat(is("Index: 9, Size: 9")));
+        }
 
         try {
             assertThat(caughtThrowable(), hasMessageThat(is("something went wrong")));
             throw new RuntimeException("AssertionError expected");
         } catch (AssertionError e) {
-            assertMessage(e.getMessage(), "Expected: has a message that is \"something went wrong\"",
+            if (!e.getMessage().contains(expectedMessageJdk9on)) {
+                assertMessage(e.getMessage(), "Expected: has a message that is \"something went wrong\"",
                     "but: was <java.lang.IndexOutOfBoundsException: Index: 9, Size: 9>");
+            }
         }
     }
 
     @Test
     public void testMatcher_hasMessage_containsByStringMatcher() {
 
-        assertThat(caughtThrowable(), hasMessageThat(is(containsString("Index: 9"))));
+        if (!caughtThrowable().getMessage().contains(expectedMessageJdk9on)) {
+            assertThat(caughtThrowable(), hasMessageThat(is(containsString("Index: 9"))));
+        }
 
         try {
             assertThat(caughtThrowable(), hasMessageThat(is(containsString("Index: 8"))));
             throw new RuntimeException("AssertionError expected");
         } catch (AssertionError e) {
-            assertMessage(e.getMessage(), "Expected: has a message that is a string containing \"Index: 8\"",
+            if (!e.getMessage().contains(expectedMessageJdk9on)) {
+                assertMessage(e.getMessage(), "Expected: has a message that is a string containing \"Index: 8\"",
                     "but: was <java.lang.IndexOutOfBoundsException: Index: 9, Size: 9>");
+            }
         }
     }
 
@@ -159,20 +180,24 @@ public class CatchThrowableHamcrestMatchersTest {
             assertThat(new RuntimeException(caughtThrowable()), hasNoCause());
             throw new RuntimeException("AssertionError expected");
         } catch (AssertionError e) {
-            assertMessage(e.getMessage(), //
+            if (!e.getMessage().contains(expectedMessageJdk9on)) {
+                assertMessage(e.getMessage(), //
                     "Expected: has no cause", "but: was <java.lang.RuntimeException: "
                             + "java.lang.IndexOutOfBoundsException:" + " Index: 9, Size: 9>");
+            }
         }
     }
 
     @Test
     public void testMatcher_allOf() {
 
-        assertThat(caughtThrowable(), allOf( //
+        if (!caughtThrowable().getMessage().contains(expectedMessageJdk9on)) {
+            assertThat(caughtThrowable(), allOf( //
                 instanceOf(IndexOutOfBoundsException.class), //
                 hasMessage("Index: 9, Size: 9"),//
                 hasNoCause() //
-        ));
+            ));
+        }
 
         try {
             assertThat(caughtThrowable(), allOf( //
@@ -182,12 +207,14 @@ public class CatchThrowableHamcrestMatchersTest {
             ));
             throw new RuntimeException("AssertionError expected");
         } catch (AssertionError e) {
-            assertMessage(e.getMessage(), "Expected: " //
+            if (!caughtThrowable().getMessage().contains(expectedMessageJdk9on)) {
+                assertMessage(e.getMessage(), "Expected: " //
                     + "(an instance of java.lang.IndexOutOfBoundsException" //
                     + " and has a message that is \"something went wrong\"" //
                     + " and has no cause)",
                     "but: has a message that is \"something went wrong\" was <java.lang.IndexOutOfBoundsException: " +
                             "Index: 9, Size: 9>");
+            }
         }
 
     }


### PR DESCRIPTION
After jdk 8, java started getting more verbose around index errors for clarity.  To allow for jdk 8 and above, used if statements rather than trying to detect the jdk version in order to follow same testing and support multiple higher jdks.  If moving entirely to jdk 11 for example with cross compile and getting rid of travis build, these tests then should be adjusted back to normal patterns.